### PR TITLE
Issue #16: Multiline string indent control does not work

### DIFF
--- a/src/Core/CodegenCS.Tests/CoreTests/30-MultilineTests.cs
+++ b/src/Core/CodegenCS.Tests/CoreTests/30-MultilineTests.cs
@@ -4,6 +4,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using static CodegenCS.Symbols;
+
 namespace CodegenCS.Tests.CoreTests
 {
     public class MultilineTests
@@ -426,8 +428,38 @@ namespace AdventureWorks
             Assert.AreEqual(expected, _w.GetContents());
         }
 
+        [Test]
+        public void TestMultilineStringWithRAW()
+        {
+            var s = @"a
+empty:
 
+b
+indented:
+    c
+empty:
 
+d";
+
+            _w.WriteLine($$"""
+                public string Test()
+                {
+                    // comment1
+                    return @"{{RAW(s)}}";
+                    // comment2
+                }
+                """);
+
+            var expected = @$"public string Test()
+{{
+    // comment1
+    return @""{s}"";
+    // comment2
+}}
+";
+
+            Assert.AreEqual(expected, _w.GetContents());
+        }
 
     }
 }

--- a/src/Core/CodegenCS/CodegenTextWriter.cs
+++ b/src/Core/CodegenCS/CodegenTextWriter.cs
@@ -624,6 +624,15 @@ namespace CodegenCS
 
         #region Raw Writes to _innerWriter (raw methods don't add any indent): InnerWriteRaw
         /// <summary>
+        /// Writes the specified string without indentation.
+        /// </summary>
+        public ICodegenTextWriter WriteRaw(string value)
+        {
+            InnerWriteRaw(value);
+            return this;
+        }
+
+        /// <summary>
         /// This is the lowest-level Write method. All writing methods end up here.
         /// </summary>
         protected void InnerWriteRaw(string value)
@@ -641,7 +650,7 @@ namespace CodegenCS
             _innerWriter.Write(value);
             OnWritten(value);
         }
-        
+
         /// <summary>
         /// Trims spaces and tabs from the end of the last line (current line), including automatically-added indentation
         /// Should only be used before writing a new linebreak
@@ -938,6 +947,13 @@ namespace CodegenCS
                 else if (arg is TrimTrailingWhitespaceSymbol)
                 {
                     _trimWhileWhitespace = true;
+                }
+                else if (arg is WriteRawSymbol)
+                {
+                    string text = ((WriteRawSymbol)arg).Text;
+
+                    if (!string.IsNullOrEmpty(text))
+                        InnerWriteRaw(text);
                 }
                 else
                     throw new NotImplementedException();

--- a/src/Core/CodegenCS/ControlFlow/WriteRawSymbol.cs
+++ b/src/Core/CodegenCS/ControlFlow/WriteRawSymbol.cs
@@ -1,0 +1,18 @@
+﻿using System.Diagnostics;
+
+namespace CodegenCS.ControlFlow
+{
+    [DebuggerDisplay("[RAW({Text,nq})]")]
+    public sealed class WriteRawSymbol : IControlFlowSymbol
+    {
+        public string Text { get; set; }
+
+        public WriteRawSymbol()
+        {
+        }
+        internal WriteRawSymbol(string text)
+        {
+            Text = text;
+        }
+    }
+}

--- a/src/Core/CodegenCS/ICodegenTextWriter.cs
+++ b/src/Core/CodegenCS/ICodegenTextWriter.cs
@@ -30,6 +30,7 @@ namespace CodegenCS
         string ToString();
         int IndentLevel { get; }
         string IndentString { get; set; }
+        ICodegenTextWriter WriteRaw(string value);
         ICodegenTextWriter IncreaseIndent();
         ICodegenTextWriter DecreaseIndent();
         ICodegenTextWriter EnsureEmptyLine();

--- a/src/Core/CodegenCS/Symbols.cs
+++ b/src/Core/CodegenCS/Symbols.cs
@@ -9,6 +9,14 @@ namespace CodegenCS
     public class Symbols
     {
         /// <summary>
+        /// Writes the specified string without indentation
+        /// </summary>
+        public static WriteRawSymbol RAW(string text)
+        {
+            return new WriteRawSymbol(text);
+        }
+
+        /// <summary>
         /// Starts a conditional block. If condition is false, everything written to TextWriter until the matching ELSE or ENDIF will be discarded.
         /// </summary>
         /// <param name="condition"></param>


### PR DESCRIPTION
As discussed in #16, here is the implementation of my two suggestions:

#### Public WriteRaw-Method
It simply calls the InnerWriteRaw method.

#### WriteRawSymbol
It writes the text using the InnerWriteRaw method.
Use as follows:

```csharp
return $$""
    return @"{{RAW(myMultilineString)}}"
    """;
```